### PR TITLE
Pin version of Open SDG to 0.4.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -112,7 +112,7 @@ plugins:
   - jekyll-open-sdg-plugins
 
 # Tell the Remote Theme plugin to use the Open SDG platform (Jekyll theme).
-remote_theme: open-sdg/open-sdg
+remote_theme: open-sdg/open-sdg@0.4.0
 
 # Apply any custom CSS.
 custom_css:


### PR DESCRIPTION
"Pinning" the version of Open SDG will help avoid unexpected changes or build failures. This way, when an "upstream" change happens in Open SDG (as happened recently) your Jekyll builds will work as expected.